### PR TITLE
Fix bug with seq and falsey values.

### DIFF
--- a/src/main/multiset/core.clj
+++ b/src/main/multiset/core.clj
@@ -41,8 +41,8 @@
 
   clojure.lang.Seqable ;----------
   (seq [this]
-    (let [k (first (keys t))]
-      (if k
+    (if-let [entry (first (seq t))]
+      (let [k (key entry)]
         (lazy-seq (cons k (.seq (.disjoin this k)))))))
 
   clojure.lang.Counted ;----------

--- a/src/test/multiset/t_core.clj
+++ b/src/test/multiset/t_core.clj
@@ -43,6 +43,10 @@
             b (ms/multiset 4 2 2 7 1)]
         (= a b) => truthy))
 
+(fact "seq retains falsey values"
+      (let [a (ms/multiset nil nil false false)]
+        (apply ms/multiset (seq a)) => a))
+
 (fact "empty multiset is a multiset"
       (instance? MultiSet (empty (ms/multiset))))
 


### PR DESCRIPTION
The seq implementation assumes it has reached the end of a list when it finds a falsey key, which bugs out multisets containing falsey values. This PR fixes this by checking if the multiplicity map contains a map entry instead of testing the key itself.