### PR TITLE
Fix empty set NPEs in iterator & toArray

### DIFF
--- a/src/main/multiset/core.clj
+++ b/src/main/multiset/core.clj
@@ -77,11 +77,11 @@
     (zero? size))
   (size [this] size)
   (toArray [this a]
-    (.toArray ^Collection (seq this) a))
+    (.toArray ^Collection (or (seq this) ()) a))
   (toArray [this]
-    (.toArray ^Collection (seq this)))
+    (.toArray ^Collection (or (seq this) ())))
   (iterator [this]
-    (.iterator ^Collection (seq this)))
+    (.iterator ^Collection (or (seq this) ())))
   (containsAll [this coll]
     (.containsAll ^Collection (into #{} this) coll))
 

--- a/src/test/multiset/t_core.clj
+++ b/src/test/multiset/t_core.clj
@@ -101,3 +101,11 @@
 (fact "empty retains meta"
       (let [m {:foo :bar}]
         (meta (empty (with-meta (ms/multiset) m))) => m))
+
+(fact "vec works"
+      (vec (ms/multiset)) => []
+      (vec (ms/multiset 9 9)) => [9 9])
+
+(fact ".toArray works"
+      (seq (.toArray (ms/multiset))) => nil
+      (seq (.toArray (ms/multiset 42 42))) => [42 42])


### PR DESCRIPTION
Have to account for `(seq this)` returning `nil` when we make interop
calls on it.

Fixes #5.