### PR TITLE
Set equality

### DIFF
--- a/src/main/multiset/core.clj
+++ b/src/main/multiset/core.clj
@@ -30,6 +30,20 @@
             (assoc t x (dec oldcount)))
           (dec size)))))
 
+  java.util.Set ;----------
+  (add [this _]
+    (throw (UnsupportedOperationException.)))
+  (addAll [this _]
+    (throw (UnsupportedOperationException.)))
+  (clear [this]
+    (throw (UnsupportedOperationException.)))
+  (remove [this _]
+    (throw (UnsupportedOperationException.)))
+  (removeAll [this _]
+    (throw (UnsupportedOperationException.)))
+  (retainAll [this _]
+    (throw (UnsupportedOperationException.)))
+
   clojure.lang.IPersistentCollection ;----------
   (cons [this x]
     (MultiSet.
@@ -57,8 +71,17 @@
 
   Object ;----------
   (equals [this x]
-    (if (instance? MultiSet x)
+    (cond
+      (instance? MultiSet x)
       (.equals t (.t ^MultiSet x))
+
+      (instance? java.util.Set x)
+      (let [x ^java.util.Set x]
+        (and (= size (.size x))
+             (= size (count t))
+             (every? #(.contains x %) (keys t))))
+
+      :else
       false))
   (hashCode [this]
     (hash-combine (hash t) MultiSet))

--- a/src/main/multiset/core.clj
+++ b/src/main/multiset/core.clj
@@ -93,7 +93,9 @@
       false))
   (hashCode [this]
     (reduce-kv (fn [acc k v]
-                 (unchecked-add-int acc (unchecked-multiply-int (.hashCode k) v)))
+                 (if (nil? k)
+                   acc
+                   (unchecked-add-int acc (unchecked-multiply-int (.hashCode k) v))))
                0
                t))
 

--- a/src/main/multiset/core.clj
+++ b/src/main/multiset/core.clj
@@ -69,6 +69,14 @@
   (withMeta [this m]
     (MultiSet. m t size))
 
+  clojure.lang.IHashEq ;----------
+  (hasheq [this]
+    (-> (reduce-kv (fn [acc k v]
+                     (unchecked-add-int acc (unchecked-multiply-int (hash k) v)))
+                   0
+                   t)
+        (mix-collection-hash size)))
+
   Object ;----------
   (equals [this x]
     (cond
@@ -84,7 +92,10 @@
       :else
       false))
   (hashCode [this]
-    (hash-combine (hash t) MultiSet))
+    (reduce-kv (fn [acc k v]
+                 (unchecked-add-int acc (unchecked-multiply-int (.hashCode k) v)))
+               0
+               t))
 
   clojure.lang.IFn ;----------
   (invoke [this x]

--- a/src/test/multiset/t_core.clj
+++ b/src/test/multiset/t_core.clj
@@ -111,9 +111,9 @@
       (seq (.toArray (ms/multiset 42 42))) => [42 42])
 
 (fact "multiset equals equivalent set"
-      (= (ms/multiset 1 2 3) #{1 2 3}) => true
-      (= #{1 2 3} (ms/multiset 1 2 3)) => true)
+      (= (ms/multiset 1 2 3 nil) #{1 2 3 nil}) => true
+      (= #{1 2 3 nil} (ms/multiset 1 2 3 nil)) => true)
 
 (fact "hash uses correct algorithm"
-      (.hashCode (ms/multiset 1 2 3)) => (.hashCode #{1 2 3})
-      (hash (ms/multiset 1 2 3)) => (hash #{1 2 3}))
+      (.hashCode (ms/multiset 1 2 3 nil)) => (.hashCode #{1 2 3 nil})
+      (hash (ms/multiset 1 2 3 nil)) => (hash #{1 2 3 nil}))

--- a/src/test/multiset/t_core.clj
+++ b/src/test/multiset/t_core.clj
@@ -20,7 +20,7 @@
         (contains? a 0) => falsey
         (contains? a 2) => truthy
         (contains? a 7) => truthy)
-  
+
   (fact "disj works correctly"
         (contains? (disj a 7) 7) => falsey
         (contains? (disj a 2) 2) => truthy
@@ -113,3 +113,7 @@
 (fact "multiset equals equivalent set"
       (= (ms/multiset 1 2 3) #{1 2 3}) => true
       (= #{1 2 3} (ms/multiset 1 2 3)) => true)
+
+(fact "hash uses correct algorithm"
+      (.hashCode (ms/multiset 1 2 3)) => (.hashCode #{1 2 3})
+      (hash (ms/multiset 1 2 3)) => (hash #{1 2 3}))

--- a/src/test/multiset/t_core.clj
+++ b/src/test/multiset/t_core.clj
@@ -109,3 +109,7 @@
 (fact ".toArray works"
       (seq (.toArray (ms/multiset))) => nil
       (seq (.toArray (ms/multiset 42 42))) => [42 42])
+
+(fact "multiset equals equivalent set"
+      (= (ms/multiset 1 2 3) #{1 2 3}) => true
+      (= #{1 2 3} (ms/multiset 1 2 3)) => true)


### PR DESCRIPTION
I think it would make sense for a multiset to equal a set when the elements are the same. This PR implements that (in both directions): `(= set multiset)` is enabled by making multiset implement the java.util.Set interface, and '(= multiset set)' is handled in the `.equals` method.

I also changed the `.hashCode` algorithm to match that used by [java.util.Set](https://docs.oracle.com/javase/7/docs/api/java/util/Set.html#hashCode()), and added support for [Clojure's hash algorithm](https://clojure.org/reference/data_structures#_clojure_collection_hashes), so that when a set and a multiset are equal, their (Java and Clojure) hashes will also be equal.

Does this look reasonable to you?