### PR TITLE
Support JDK 11 by hinting toArray

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,10 +12,10 @@
   :source-paths ["src" "src/main"]
   :test-paths ["test" "src/test"]
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
+  :dependencies [[org.clojure/clojure "1.7.0" :scope "provided"]
                  [org.clojure/algo.generic "0.1.2"]]
 
-  :profiles {:dev {:dependencies [[midje "1.6.3"]]
+  :profiles {:dev {:dependencies [[midje "1.9.6"]]
                    :plugins [[lein-html5-docs "3.0.1"]
                              [lein-midje "3.1.3"]]
                    :html5-docs-docs-dir "doc"

--- a/src/main/multiset/core.clj
+++ b/src/main/multiset/core.clj
@@ -76,7 +76,7 @@
   (isEmpty [this]
     (zero? size))
   (size [this] size)
-  (toArray [this a]
+  (^objects toArray [this ^objects a]
     (.toArray ^Collection (or (seq this) ()) a))
   (toArray [this]
     (.toArray ^Collection (or (seq this) ())))


### PR DESCRIPTION
Fixes `Exception in thread "main" Syntax error compiling deftype* at (multiset/core.clj:11:1)` when using `v0.1.0` with JDK 11.