### PR TITLE
Fix typehint errors on toArray

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -12,10 +12,10 @@
   :source-paths ["src" "src/main"]
   :test-paths ["test" "src/test"]
 
-  :dependencies [[org.clojure/clojure "1.6.0"]
-                 [org.clojure/algo.generic "0.1.2"]]
+  :dependencies [[org.clojure/clojure "1.10.1"]
+                 [org.clojure/algo.generic "0.1.3"]]
 
-  :profiles {:dev {:dependencies [[midje "1.6.3"]]
+  :profiles {:dev {:dependencies [[midje "1.9.9"]]
                    :plugins [[lein-html5-docs "3.0.1"]
                              [lein-midje "3.1.3"]]
                    :html5-docs-docs-dir "doc"

--- a/src/main/multiset/core.clj
+++ b/src/main/multiset/core.clj
@@ -76,9 +76,9 @@
   (isEmpty [this]
     (zero? size))
   (size [this] size)
-  (toArray [this a]
-    (.toArray ^Collection (or (seq this) ()) a))
-  (toArray [this]
+  (^objects toArray [this ^objects a]
+    (.toArray ^Collection (or (seq this) ()) ^objects a))
+  (^objects toArray [^objects this]
     (.toArray ^Collection (or (seq this) ())))
   (iterator [this]
     (.iterator ^Collection (or (seq this) ())))


### PR DESCRIPTION
Fix Must hint overloaded method: toArray when running on jdk 13. I
believe a change in overload resolution happened on java 11

similar fixes:

https://github.com/clojure/data.avl/commit/03f32144951ab7b50b8a74ea5e8c22629e7fbde0
https://github.com/clojure/core.rrb-vector/commit/b489b3249d56bb6a104c2d4ead2da8ade8dd29b4

Had to bump midje for a similar reason in ordered/set.